### PR TITLE
windows: fix assignment from distinct type

### DIFF
--- a/enet.nim
+++ b/enet.nim
@@ -307,7 +307,7 @@ when defined(Linux):
 elif defined(Windows):
   ## put the content of win32.h in here
   import winlean
-  let ENET_SOCKET_NULL*: cint = INVALID_SOCKET
+  let ENET_SOCKET_NULL*: cint = INVALID_SOCKET.cint
   type
     TENetSocket* = winlean.SocketHandle
     TEnetBuffer* = object


### PR DESCRIPTION
INVALID_SOCKET is a "distinct int" type on Windows and can't be implicitly converted. This patch resolves the compilation error.